### PR TITLE
docs: Update usage instructions to correct source and versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - '**/*.tf'
+      - '**/*.md'
+      - 'LICENSE'
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This module assumes the resources specified have been created in Snowflake by ot
 
 ```hcl
 module "rbac" {
-  source  = "Infostrux-Solutions/terraform-snowflake-rbac"
-  version = "~> 1.0.0"
+  source  = "Infostrux-Solutions/rbac/snowflake"
+  version = "1.0.0"
 
   providers = {
     snowflake = snowflake.securityadmin


### PR DESCRIPTION
Updating the usage instructions in the README to reference the correct source and version path in the Terraform registry.