### PR TITLE
ci: Use github-actions[bot] as format commits user

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,14 +13,20 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ secrets.TERRAFORM_FMT_TOKEN }}
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: "1.0.0"
     - name: Format Code
       run: |
-        terraform fmt .
-    - name: Push Formatted Code
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: "terraform-fmt: automated action"
+        make tf-fmt
+    - name: Commit Format Changes
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git add .
+        git diff-index --quiet HEAD || git commit -m "terraform-fmt: Auto format codebase"
+        git push

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
         terraform_version: "1.0.0"
     - name: Format Code
       run: |
-        make tf-fmt
+        terraform fmt -recursive .
     - name: Commit Format Changes
       run: |
         git config user.name 'github-actions[bot]'


### PR DESCRIPTION
Currently, the Format Pipeline will automatically format the Terraform code and commit changes directly to the source branch for a PR. However, this commit will not trigger another status check run.

To address this, we must add a token to the checkout action. When doing this, we would also like to migrate away from using an upstream Action and use the `github-actions[bot]` user directly.