### PR TITLE
chore: Bump cycjimmy/semantic-release-action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3.1.1
         with:
           semantic_version: 19.0.5
           extra_plugins: |

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,6 @@
     "main"
   ],
   "ci": false,
-  "dryRun": true,
   "plugins": [
     [
       "@semantic-release/commit-analyzer",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,7 @@
     "main"
   ],
   "ci": false,
+  "dryRun": true,
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
This PR addresses the following warnings annotated to the Release pipeline jobs:

>Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: cycjimmy/semantic-release-action